### PR TITLE
make sure Garmin::FIT is in @INC

### DIFF
--- a/fit2gpx.pl
+++ b/fit2gpx.pl
@@ -1,6 +1,8 @@
 #!/usr/bin/perl
 use strict;
 use warnings;
+use FindBin;
+use lib $FindBin::RealBin;
 
 use Garmin::FIT;
 use POSIX;

--- a/fit2slf.pl
+++ b/fit2slf.pl
@@ -1,6 +1,8 @@
 #!/usr/bin/perl
 use strict;
 use warnings;
+use FindBin;
+use lib $FindBin::RealBin;
 
 use Garmin::FIT;
 use POSIX;

--- a/fitdump.pl
+++ b/fitdump.pl
@@ -1,5 +1,8 @@
 #! /usr/bin/perl -s
 
+use FindBin;
+use lib $FindBin::RealBin;
+
 use Garmin::FIT;
 
 $use_gmtime = 0 if !defined $use_gmtime;


### PR DESCRIPTION
Newer perls (e.g. 5.27.x) removed . from @INC, so using the bundled
Garmin::FIT fails on such systems. Also, this way it's possible to
call fit2gpx.pl and the other scripts without cd'ing to this
directory.